### PR TITLE
Add test helper utilities for integration testing and refactor tests to improve reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,4 @@ examples/certs/*-private.pem
 tests/certs/*
 /examples/certs
 examples/Authentication/certs/*
+pode-plus.sln

--- a/tests/integration/Authentication.Tests.ps1
+++ b/tests/integration/Authentication.Tests.ps1
@@ -5,6 +5,8 @@ BeforeAll {
     $path = $PSCommandPath
     $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]integration', '/src/'
     Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
+    $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+    . "$helperPath/TestHelper.ps1"
 }
 Describe 'Authentication Requests' {
 
@@ -111,7 +113,7 @@ Describe 'Authentication Requests' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port
     }
 
     AfterAll {

--- a/tests/integration/DigestAuthentication.Tests.ps1
+++ b/tests/integration/DigestAuthentication.Tests.ps1
@@ -3,10 +3,11 @@
 param()
 BeforeAll {
     $path = $PSCommandPath
-    $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]integration', '/src/'
-    $CertsPath = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]integration', '/tests/certs/'
-    Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
-    
+    # $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]integration', '/src/'
+    # Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
+    $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+    . "$helperPath/TestHelper.ps1"
+
     # load assemblies
     Add-Type -AssemblyName System.Web -ErrorAction Stop
     Add-Type -AssemblyName System.Net.Http -ErrorAction Stop
@@ -311,7 +312,7 @@ Describe 'Digest Authentication Requests' {
                 }
             }
         }
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port
 
     }
 

--- a/tests/integration/Endpoints.Tests.ps1
+++ b/tests/integration/Endpoints.Tests.ps1
@@ -4,6 +4,9 @@ param()
 Describe 'Endpoint Requests' {
 
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+        
         $Port1 = 8080
         $Endpoint1 = "http://127.0.0.1:$($Port1)"
 
@@ -36,7 +39,8 @@ Describe 'Endpoint Requests' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port1
+        Wait-ForWebServer -Port $Port2
     }
 
     AfterAll {

--- a/tests/integration/JWTAuthentication.Tests.ps1
+++ b/tests/integration/JWTAuthentication.Tests.ps1
@@ -6,6 +6,8 @@ BeforeAll {
     $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]integration', '/src/'
     $CertsPath = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]integration', '/tests/certs/'
     Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
+    $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+    . "$helperPath/TestHelper.ps1"
 }
 
 Describe 'JWT Bearer Authentication Requests' {
@@ -247,7 +249,7 @@ Describe 'JWT Bearer Authentication Requests' {
                         Write-PodeJsonResponse -StatusCode 200 -Value @{
                             'success' = $true
                             'user'    = $user
-                            'token'     = $jwt
+                            'token'   = $jwt
                         }
 
                     }
@@ -264,7 +266,7 @@ Describe 'JWT Bearer Authentication Requests' {
 
                         Write-PodeJsonResponse -StatusCode 200 -Value @{
                             'success' = $true
-                            'token'     = $jwt
+                            'token'   = $jwt
                         }
                     }
                     catch {
@@ -286,7 +288,7 @@ Describe 'JWT Bearer Authentication Requests' {
             }
         }
 
-        Start-Sleep -Seconds 20
+        Wait-ForWebServer -Port $Port
     }
 
     AfterAll {
@@ -555,7 +557,7 @@ Describe 'JWT Bearer Authentication Requests' {
                 -Headers @{
                 'accept'        = 'application/json'
                 'Authorization' = "Bearer $($script:JwtToken)"
-            } 
+            }
 
             # Validate response structure
             $Response | Should -Not -BeNullOrEmpty

--- a/tests/integration/OpenApi.Tests.ps1
+++ b/tests/integration/OpenApi.Tests.ps1
@@ -5,6 +5,10 @@ param()
 Describe 'OpenAPI integration tests' {
 
     BeforeAll {
+
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+
         $mindyCommonHeaders = @{
             'accept'        = 'application/json'
             'X-API-KEY'     = 'test2-api-key'
@@ -19,137 +23,9 @@ Describe 'OpenAPI integration tests' {
         $PortV3 = 8080
         $PortV3_1 = 8081
         $scriptPath = "$($PSScriptRoot)\..\..\examples\OpenApi-TuttiFrutti.ps1"
-        Start-Process (Get-Process -Id $PID).Path -ArgumentList "-NoProfile -File `"$scriptPath`" -PortV3 $PortV3 -PortV3_1 $PortV3_1 -Daemon -IgnoreServerConfig"   -NoNewWindow
+        Start-Process (Get-Process -Id $PID).Path -ArgumentList "-NoProfile -File `"$scriptPath`" -PortV3 $PortV3 -PortV3_1 $PortV3_1 -Daemon -IgnoreServerConfig" -NoNewWindow
 
-        function Compare-StringRnLn {
-            param (
-                [string]$InputString1,
-                [string]$InputString2
-            )
-            return ($InputString1.Trim() -replace "`r`n|`n|`r", "`n") -eq ($InputString2.Trim() -replace "`r`n|`n|`r", "`n")
-        }
-
-        function Convert-PsCustomObjectToOrderedHashtable {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-                [PSCustomObject]$InputObject
-            )
-            begin {
-                # Define a recursive function within the process block
-                function Convert-ObjectRecursively {
-                    param (
-                        [Parameter(Mandatory = $true)]
-                        [System.Object]
-                        $InputObject
-                    )
-
-                    # Initialize an ordered dictionary
-                    $orderedHashtable = [ordered]@{}
-
-                    # Loop through each property of the PSCustomObject
-                    foreach ($property in $InputObject.PSObject.Properties) {
-                        # Check if the property value is a PSCustomObject
-                        if ($property.Value -is [PSCustomObject]) {
-                            # Recursively convert the nested PSCustomObject
-                            $orderedHashtable[$property.Name] = Convert-ObjectRecursively -InputObject $property.Value
-                        }
-                        elseif ($property.Value -is [System.Collections.IEnumerable] -and -not ($property.Value -is [string])) {
-                            # If the value is a collection, check each element
-                            $convertedCollection = @()
-                            foreach ($item in $property.Value) {
-                                if ($item -is [PSCustomObject]) {
-                                    $convertedCollection += Convert-ObjectRecursively -InputObject $item
-                                }
-                                else {
-                                    $convertedCollection += $item
-                                }
-                            }
-                            $orderedHashtable[$property.Name] = $convertedCollection
-                        }
-                        else {
-                            # Add the property name and value to the ordered hashtable
-                            $orderedHashtable[$property.Name] = $property.Value
-                        }
-                    }
-
-                    # Return the resulting ordered hashtable
-                    return $orderedHashtable
-                }
-            }
-            process {
-                # Call the recursive helper function for each input object
-                Convert-ObjectRecursively -InputObject $InputObject
-            }
-        }
-
-        function Compare-Hashtable {
-            param (
-                [object]$Hashtable1,
-                [object]$Hashtable2
-            )
-
-            # Function to compare two hashtable values
-            function Compare-Value($value1, $value2) {
-                # Check if both values are hashtables
-                if ((($value1 -is [hashtable] -or $value1 -is [System.Collections.Specialized.OrderedDictionary]) -and
-            ($value2 -is [hashtable] -or $value2 -is [System.Collections.Specialized.OrderedDictionary]))) {
-                    return Compare-Hashtable -Hashtable1 $value1 -Hashtable2 $value2
-                }
-                # Check if both values are arrays
-                elseif (($value1 -is [Object[]]) -and ($value2 -is [Object[]])) {
-                    if ($value1.Count -ne $value2.Count) {
-                        return $false
-                    }
-                    for ($i = 0; $i -lt $value1.Count; $i++) {
-                        $found = $false
-                        for ($j = 0; $j -lt $value2.Count; $j++) {
-                            if ( Compare-Value $value1[$i] $value2[$j]) {
-                                $found = $true
-                            }
-                        }
-                        if ($found -eq $false) {
-                            return $false
-                        }
-                    }
-                    return $true
-                }
-                else {
-                    if ($value1 -is [string] -and $value2 -is [string]) {
-                        return  Compare-StringRnLn $value1 $value2
-                    }
-                    # Check if the values are equal
-                    return $value1 -eq $value2
-                }
-            }
-
-            $keys1 = $Hashtable1.Keys
-            $keys2 = $Hashtable2.Keys
-
-            # Check if both hashtables have the same keys
-            if ($keys1.Count -ne $keys2.Count) {
-                return $false
-            }
-
-            foreach ($key in $keys1) {
-                if (! ($Hashtable2.Keys -contains $key)) {
-                    return $false
-                }
-
-                if ($Hashtable2[$key] -is [hashtable] -or $Hashtable2[$key] -is [System.Collections.Specialized.OrderedDictionary]) {
-                    if (! (Compare-Hashtable -Hashtable1 $Hashtable1[$key] -Hashtable2 $Hashtable2[$key])) {
-                        return $false
-                    }
-                }
-                elseif (!(Compare-Value $Hashtable1[$key] $Hashtable2[$key])) {
-                    return $false
-                }
-            }
-
-            return $true
-        }
-
-        Start-Sleep -Seconds 5
+        Wait-ForWebServer -Port $PortV3
     }
 
     AfterAll {
@@ -161,7 +37,6 @@ Describe 'OpenAPI integration tests' {
     Describe 'OpenAPI' {
         it 'Open API v3.0.3' {
 
-            Start-Sleep -Seconds 10
             $fileContent = Get-Content -Path "$PSScriptRoot/specs/OpenApi-TuttiFrutti_3.0.3.json"
 
             $webResponse = Invoke-WebRequest -Uri "http://localhost:$($PortV3)/docs/openapi/v3.0" -Method Get

--- a/tests/integration/RestApi.Https.Tests.ps1
+++ b/tests/integration/RestApi.Https.Tests.ps1
@@ -4,6 +4,9 @@ param()
 
 Describe 'REST API Requests' {
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+
         $splatter = @{}
         $version = $PSVersionTable.PSVersion
         $useCurl = $false
@@ -31,7 +34,7 @@ Describe 'REST API Requests' {
             $splatter.SkipCertificateCheck = $true
         }
 
-        $Port = 8080
+        $Port = 8043
         $Endpoint = "https://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {
@@ -117,7 +120,7 @@ Describe 'REST API Requests' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Protocol https -Port $Port
     }
 
     AfterAll {

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -5,6 +5,9 @@ param()
 Describe 'REST API Requests' {
 
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+
         $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
@@ -91,7 +94,7 @@ Describe 'REST API Requests' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port
     }
 
     AfterAll {

--- a/tests/integration/Schedules.Tests.ps1
+++ b/tests/integration/Schedules.Tests.ps1
@@ -5,6 +5,9 @@ param()
 Describe 'Schedules' {
 
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+
         $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
@@ -74,7 +77,7 @@ Describe 'Schedules' {
             }
         }
 
-        Start-Sleep -Seconds 10
+         Wait-ForWebServer -Port $Port
     }
 
     AfterAll {

--- a/tests/integration/Service.Tests.ps1
+++ b/tests/integration/Service.Tests.ps1
@@ -11,13 +11,19 @@ Describe 'Service Lifecycle' {
         if ($IsMacOS) {
             $isAgent = $true
         }
+
+        $Uri = 'http://localhost:8080'
+        $SleepTime = 3
+
     }
     it 'register' {
         $success = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Register -Agent:$isAgent
         $success | Should -BeTrue
-        Start-Sleep 10
+        Start-Sleep -Seconds $SleepTime
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         if ($IsMacOS) {
+            Start-Sleep -Seconds $10
+            $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
             $status.Status | Should -Be 'Running'
             $status.Pid | Should -BeGreaterThan 0
         }
@@ -34,8 +40,7 @@ Describe 'Service Lifecycle' {
     it 'start' -Skip:( $IsMacOS) {
         $success = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Start -Agent:$isAgent
         $success | Should -BeTrue
-        Start-Sleep 2
-        $webRequest = Invoke-WebRequest -uri http://localhost:8080 -ErrorAction SilentlyContinue
+        $webRequest = Invoke-WebRequest -Uri $Uri -ErrorAction SilentlyContinue
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         $status.Status | Should -Be 'Running'
         $status.Name | Should -Be 'Hello Service'
@@ -46,20 +51,20 @@ Describe 'Service Lifecycle' {
     it  'pause' {
         $success = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Suspend -Agent:$isAgent
         $success | Should -BeTrue
-        Start-Sleep 2
+        Start-Sleep -Seconds $SleepTime
 
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         $status.Status | Should -Be 'Suspended'
         $status.Name | Should -Be 'Hello Service'
         $status.Pid | Should -BeGreaterThan 0
-        { Invoke-WebRequest -uri http://localhost:8080 } | Should -Throw
+        { Invoke-WebRequest -Uri $Uri } | Should -Throw
     }
 
     it  'resume' {
         $success = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -resume -Agent:$isAgent
         $success | Should -BeTrue
-        Start-Sleep 2
-        $webRequest = Invoke-WebRequest -uri http://localhost:8080 -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds $SleepTime
+        $webRequest = Invoke-WebRequest -Uri $Uri -ErrorAction SilentlyContinue
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         $status.Status | Should -Be 'Running'
         $status.Name | Should -Be 'Hello Service'
@@ -69,20 +74,20 @@ Describe 'Service Lifecycle' {
     it 'stop' {
         $success = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Stop -Agent:$isAgent
         $success | Should -BeTrue
-        Start-Sleep 2
+        Start-Sleep -Seconds $SleepTime
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         $status.Status | Should -Be 'Stopped'
         $status.Name | Should -Be 'Hello Service'
         $status.Pid | Should -Be 0
 
-        { Invoke-WebRequest -uri http://localhost:8080 } | Should -Throw
+        { Invoke-WebRequest -Uri $Uri } | Should -Throw
     }
 
     it 're-start' {
         $success = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Start -Agent:$isAgent
         $success | Should -BeTrue
-        Start-Sleep 2
-        $webRequest = Invoke-WebRequest -uri http://localhost:8080 -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds $SleepTime
+        $webRequest = Invoke-WebRequest -Uri $Uri -ErrorAction SilentlyContinue
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         $status.Status | Should -Be 'Running'
         $status.Name | Should -Be 'Hello Service'
@@ -95,13 +100,16 @@ Describe 'Service Lifecycle' {
     it 'unregister' {
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         $status.Status | Should -Be 'Running'
-        $isAgent = $status.Type -eq 'Agent'
+        $status.Name | Should -Be 'Hello Service'
+        if ($isAgent) {
+            $status.Type | Should -Be 'Agent'
+        }
         $success = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Unregister -Force -Agent:$isAgent
         $success | Should -BeTrue
-        Start-Sleep 2
+        Start-Sleep -Seconds $SleepTime
         $status = & "$($PSScriptRoot)\..\..\examples\HelloService\HelloService.ps1" -Query -Agent:$isAgent
         $status | Should -BeNullOrEmpty
-        { Invoke-WebRequest -uri http://localhost:8080 } | Should -Throw
+        { Invoke-WebRequest -Uri $Uri } | Should -Throw
     }
 
 }

--- a/tests/integration/Sessions.Tests.ps1
+++ b/tests/integration/Sessions.Tests.ps1
@@ -5,13 +5,16 @@ param()
 Describe 'Session Requests' {
 
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+
         $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {
             Import-Module -Name "$($using:PSScriptRoot)\..\..\src\Pode.psm1"
 
-            Start-PodeServer -Quiet -ScriptBlock {
+            Start-PodeServer   -Daemon -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
@@ -41,7 +44,7 @@ Describe 'Session Requests' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port
     }
 
     AfterAll {

--- a/tests/integration/Timers.Tests.ps1
+++ b/tests/integration/Timers.Tests.ps1
@@ -4,6 +4,9 @@ param()
 Describe 'Timers' {
 
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+
         $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
@@ -30,7 +33,7 @@ Describe 'Timers' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port
     }
 
     AfterAll {

--- a/tests/integration/WebPages.Tests.ps1
+++ b/tests/integration/WebPages.Tests.ps1
@@ -3,6 +3,9 @@ param()
 Describe 'Web Page Requests' {
 
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+
         $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
@@ -37,7 +40,7 @@ Describe 'Web Page Requests' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port
     }
 
     AfterAll {

--- a/tests/integration/WebSocket.Tests.ps1
+++ b/tests/integration/WebSocket.Tests.ps1
@@ -4,6 +4,9 @@ param()
 Describe 'WebSocket' {
 
     BeforeAll {
+        $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
+        . "$helperPath/TestHelper.ps1"
+        
         $Port = 8080
         $Endpoint = "http://localhost:$($Port)"
 
@@ -41,7 +44,7 @@ Describe 'WebSocket' {
             }
         }
 
-        Start-Sleep -Seconds 10
+        Wait-ForWebServer -Port $Port
     }
 
     AfterAll {

--- a/tests/shared/TestHelper.ps1
+++ b/tests/shared/TestHelper.ps1
@@ -1,3 +1,5 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '')]
+param()
 <#
 .SYNOPSIS
 	Ensures the Pode assembly is loaded into the current session.
@@ -49,8 +51,156 @@ function Import-PodeAssembly {
 }
 
 
+<#
+.SYNOPSIS
+  Compares two strings while normalizing line endings.
 
+.DESCRIPTION
+  This function trims both input strings and replaces all variations of line endings (`CRLF`, `LF`, `CR`) with a normalized `LF` (`\n`).
+  It then compares the normalized strings for equality.
 
+.PARAMETER InputString1
+  The first string to compare.
+
+.PARAMETER InputString2
+  The second string to compare.
+
+.OUTPUTS
+  [bool]
+  Returns `$true` if both strings are equal after normalization; otherwise, returns `$false`.
+
+.EXAMPLE
+  Compare-StringRnLn -InputString1 "Hello`r`nWorld" -InputString2 "Hello`nWorld"
+  # Returns: $true
+
+.EXAMPLE
+  Compare-StringRnLn -InputString1 "Line1`r`nLine2" -InputString2 "Line1`rLine2"
+  # Returns: $true
+
+.NOTES
+  This function ensures that strings with different line-ending formats are treated as equal if their content is otherwise identical.
+#>
+function Compare-StringRnLn {
+    param (
+        [string]$InputString1,
+        [string]$InputString2
+    )
+    return ($InputString1.Trim() -replace "`r`n|`n|`r", "`n") -eq ($InputString2.Trim() -replace "`r`n|`n|`r", "`n")
+}
+
+<#
+.SYNOPSIS
+  Converts a PSCustomObject into an ordered hashtable.
+
+.DESCRIPTION
+  This function recursively converts a PSCustomObject, including nested objects and collections, into an ordered hashtable.
+  It ensures that all properties are retained while maintaining their original structure.
+
+.PARAMETER InputObject
+  The PSCustomObject to be converted into an ordered hashtable.
+
+.OUTPUTS
+  [System.Collections.Specialized.OrderedDictionary]
+  Returns an ordered hashtable representation of the input PSCustomObject.
+
+.EXAMPLE
+  $object = [PSCustomObject]@{ Name = "Pode"; Version = "2.0"; Config = [PSCustomObject]@{ Debug = $true } }
+  Convert-PsCustomObjectToOrderedHashtable -InputObject $object
+  # Returns: An ordered hashtable representation of $object.
+
+.EXAMPLE
+  $object = [PSCustomObject]@{ Users = @([PSCustomObject]@{ Name = "Alice" }, [PSCustomObject]@{ Name = "Bob" }) }
+  Convert-PsCustomObjectToOrderedHashtable -InputObject $object
+  # Returns: An ordered hashtable where 'Users' is an array of ordered hashtables.
+
+.NOTES
+  This function preserves key order and supports recursive conversion of nested objects and collections.
+#>
+function Convert-PsCustomObjectToOrderedHashtable {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [PSCustomObject]$InputObject
+    )
+    begin {
+        # Define a recursive function within the process block
+        function Convert-ObjectRecursively {
+            param (
+                [Parameter(Mandatory = $true)]
+                [System.Object]
+                $InputObject
+            )
+
+            # Initialize an ordered dictionary
+            $orderedHashtable = [ordered]@{}
+
+            # Loop through each property of the PSCustomObject
+            foreach ($property in $InputObject.PSObject.Properties) {
+                # Check if the property value is a PSCustomObject
+                if ($property.Value -is [PSCustomObject]) {
+                    # Recursively convert the nested PSCustomObject
+                    $orderedHashtable[$property.Name] = Convert-ObjectRecursively -InputObject $property.Value
+                }
+                elseif ($property.Value -is [System.Collections.IEnumerable] -and -not ($property.Value -is [string])) {
+                    # If the value is a collection, check each element
+                    $convertedCollection = @()
+                    foreach ($item in $property.Value) {
+                        if ($item -is [PSCustomObject]) {
+                            $convertedCollection += Convert-ObjectRecursively -InputObject $item
+                        }
+                        else {
+                            $convertedCollection += $item
+                        }
+                    }
+                    $orderedHashtable[$property.Name] = $convertedCollection
+                }
+                else {
+                    # Add the property name and value to the ordered hashtable
+                    $orderedHashtable[$property.Name] = $property.Value
+                }
+            }
+
+            # Return the resulting ordered hashtable
+            return $orderedHashtable
+        }
+    }
+    process {
+        # Call the recursive helper function for each input object
+        Convert-ObjectRecursively -InputObject $InputObject
+    }
+}
+
+<#
+.SYNOPSIS
+  Compares two hashtables to determine if they are equal.
+
+.DESCRIPTION
+  This function recursively compares two hashtables, checking whether they contain the same keys and values.
+  It also handles nested hashtables and arrays, ensuring deep comparison of all elements.
+
+.PARAMETER Hashtable1
+  The first hashtable to compare.
+
+.PARAMETER Hashtable2
+  The second hashtable to compare.
+
+.OUTPUTS
+  [bool]
+  Returns `$true` if both hashtables are equal, otherwise returns `$false`.
+
+.EXAMPLE
+  $hash1 = @{ Name = "Pode"; Version = "2.0"; Config = @{ Debug = $true } }
+  $hash2 = @{ Name = "Pode"; Version = "2.0"; Config = @{ Debug = $true } }
+  Compare-Hashtable -Hashtable1 $hash1 -Hashtable2 $hash2
+  # Returns: $true
+
+.EXAMPLE
+  $hash1 = @{ Name = "Pode"; Version = "2.0" }
+  $hash2 = @{ Name = "Pode"; Version = "2.1" }
+  Compare-Hashtable -Hashtable1 $hash1 -Hashtable2 $hash2
+  # Returns: $false
+
+#>
 function Compare-Hashtable {
     param (
         [object]$Hashtable1,
@@ -118,195 +268,96 @@ function Compare-Hashtable {
 }
 
 
-function Compare-StringRnLn {
+<#
+.SYNOPSIS
+  Waits for a web server to become available at a specified URI or port.
+
+.DESCRIPTION
+  This function continuously checks if a web server is online by sending an HTTP request.
+  It retries until the server responds with a 200 status code or a timeout is reached.
+
+.PARAMETER Uri
+  The full URI to check (e.g., "http://127.0.0.1:5000"). If not provided, defaults to "http://localhost:$Port".
+
+.PARAMETER Port
+  The port on which the web server is expected to be available. If no URI is provided, the function constructs a default URI using "http://localhost:$Port".
+
+.PARAMETER Timeout
+  The maximum number of seconds to wait before timing out. Default is 60 seconds.
+
+.PARAMETER Interval
+  The number of seconds to wait between retries. Default is 2 seconds.
+
+.OUTPUTS
+  Boolean - Returns $true if the server is online, otherwise $false.
+
+.EXAMPLE
+  Wait-ForWebServer -Port 8080 -Timeout 30 -Interval 2
+
+  Waits up to 30 seconds for the web server on port 8080 to come online.
+
+.EXAMPLE
+  Wait-ForWebServer -Uri "http://127.0.0.1:5000" -Timeout 45
+
+  Waits up to 45 seconds for the web server at "http://127.0.0.1:5000" to respond.
+
+.NOTES
+  Author: ChatGPT
+  This function ensures that the web server is fully responding, not just that the port is open.
+#>
+function Wait-ForWebServer {
+    [CmdletBinding(DefaultParameterSetName = 'localhost')]
+    [OutputType([bool])]
     param (
-        [string]$InputString1,
-        [string]$InputString2
-    )
-    return ($InputString1.Trim() -replace "`r`n|`n|`r", "`n") -eq ($InputString2.Trim() -replace "`r`n|`n|`r", "`n")
-}
+        [Parameter(Mandatory = $true, ParameterSetName = 'Uri' )]
+        [string]$Uri,
 
-function Convert-PsCustomObjectToOrderedHashtable {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [PSCustomObject]$InputObject
-    )
-    begin {
-        # Define a recursive function within the process block
-        function Convert-ObjectRecursively {
-            param (
-                [Parameter(Mandatory = $true)]
-                [System.Object]
-                $InputObject
-            )
+        [Parameter(ParameterSetName = 'localhost' )]
+        [ValidateSet('http', 'https')]
+        [string]$Protocol = 'http',
 
-            # Initialize an ordered dictionary
-            $orderedHashtable = [ordered]@{}
+        [Parameter(ParameterSetName = 'localhost' )]
+        [int]$Port,
 
-            # Loop through each property of the PSCustomObject
-            foreach ($property in $InputObject.PSObject.Properties) {
-                # Check if the property value is a PSCustomObject
-                if ($property.Value -is [PSCustomObject]) {
-                    # Recursively convert the nested PSCustomObject
-                    $orderedHashtable[$property.Name] = Convert-ObjectRecursively -InputObject $property.Value
-                }
-                elseif ($property.Value -is [System.Collections.IEnumerable] -and -not ($property.Value -is [string])) {
-                    # If the value is a collection, check each element
-                    $convertedCollection = @()
-                    foreach ($item in $property.Value) {
-                        if ($item -is [PSCustomObject]) {
-                            $convertedCollection += Convert-ObjectRecursively -InputObject $item
-                        }
-                        else {
-                            $convertedCollection += $item
-                        }
-                    }
-                    $orderedHashtable[$property.Name] = $convertedCollection
-                }
-                else {
-                    # Add the property name and value to the ordered hashtable
-                    $orderedHashtable[$property.Name] = $property.Value
-                }
-            }
+        [Parameter()]
+        [int]$Timeout = 60,
 
-            # Return the resulting ordered hashtable
-            return $orderedHashtable
-        }
-    }
-    process {
-        # Call the recursive helper function for each input object
-        Convert-ObjectRecursively -InputObject $InputObject
-    }
-}
-
-
-function Compare-Hashtable {
-    param (
-        [object]$Hashtable1,
-        [object]$Hashtable2
+        [Parameter()]
+        [int]$Interval = 2
     )
 
-    # Function to compare two hashtable values
-    function Compare-Value($value1, $value2) {
-        # Check if both values are hashtables
-        if ((($value1 -is [hashtable] -or $value1 -is [System.Collections.Specialized.OrderedDictionary]) -and
-    ($value2 -is [hashtable] -or $value2 -is [System.Collections.Specialized.OrderedDictionary]))) {
-            return Compare-Hashtable -Hashtable1 $value1 -Hashtable2 $value2
-        }
-        # Check if both values are arrays
-        elseif (($value1 -is [Object[]]) -and ($value2 -is [Object[]])) {
-            if ($value1.Count -ne $value2.Count) {
-                return $false
-            }
-            for ($i = 0; $i -lt $value1.Count; $i++) {
-                $found = $false
-                for ($j = 0; $j -lt $value2.Count; $j++) {
-                    if ( Compare-Value $value1[$i] $value2[$j]) {
-                        $found = $true
-                    }
-                }
-                if ($found -eq $false) {
-                    return $false
-                }
-            }
-            return $true
+    # Determine the final URI: If no URI is provided, use "http://localhost:$Port"
+    if (-not $Uri) {
+        if ($Port -gt 0) {
+            $Uri = "$($Protocol)://localhost:$Port"
         }
         else {
-            if ($value1 -is [string] -and $value2 -is [string]) {
-                return  Compare-StringRnLn $value1 $value2
+            $Uri = "$($Protocol)://localhost"
+        }
+    }
+
+    $MaxRetries = [math]::Ceiling($Timeout / $Interval)
+    $RetryCount = 0
+
+    while ($RetryCount -lt $MaxRetries) {
+        try {
+            # Send a request but ignore status codes (any response means the server is online)
+            $null = Invoke-WebRequest -Uri $Uri -UseBasicParsing -TimeoutSec 3 -SkipCertificateCheck
+            Write-Host "Webserver is online at $Uri"
+            return $true
+        }
+        catch {
+            if ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 404) {
+                return $true
             }
-            # Check if the values are equal
-            return $value1 -eq $value2
-        }
-    }
-
-    $keys1 = $Hashtable1.Keys
-    $keys2 = $Hashtable2.Keys
-
-    # Check if both hashtables have the same keys
-    if ($keys1.Count -ne $keys2.Count) {
-        return $false
-    }
-
-    foreach ($key in $keys1) {
-        if (! ($Hashtable2.Keys -contains $key)) {
-            return $false
-        }
-
-        if ($Hashtable2[$key] -is [hashtable] -or $Hashtable2[$key] -is [System.Collections.Specialized.OrderedDictionary]) {
-            if (! (Compare-Hashtable -Hashtable1 $Hashtable1[$key] -Hashtable2 $Hashtable2[$key])) {
-                return $false
+            else {
+                Write-Host "Waiting for webserver to come online at $Uri... (Attempt $($RetryCount+1)/$MaxRetries)"
             }
         }
-        elseif (!(Compare-Value $Hashtable1[$key] $Hashtable2[$key])) {
-            return $false
-        }
+
+        Start-Sleep -Seconds $Interval
+        $RetryCount++
     }
 
-    return $true
+    return $false
 }
-
-
-function Compare-StringRnLn {
-    param (
-        [string]$InputString1,
-        [string]$InputString2
-    )
-    return ($InputString1.Trim() -replace "`r`n|`n|`r", "`n") -eq ($InputString2.Trim() -replace "`r`n|`n|`r", "`n")
-}
-
-function Convert-PsCustomObjectToOrderedHashtable {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [PSCustomObject]$InputObject
-    )
-    begin {
-        # Define a recursive function within the process block
-        function Convert-ObjectRecursively {
-            param (
-                [Parameter(Mandatory = $true)]
-                [System.Object]
-                $InputObject
-            )
-
-            # Initialize an ordered dictionary
-            $orderedHashtable = [ordered]@{}
-
-            # Loop through each property of the PSCustomObject
-            foreach ($property in $InputObject.PSObject.Properties) {
-                # Check if the property value is a PSCustomObject
-                if ($property.Value -is [PSCustomObject]) {
-                    # Recursively convert the nested PSCustomObject
-                    $orderedHashtable[$property.Name] = Convert-ObjectRecursively -InputObject $property.Value
-                }
-                elseif ($property.Value -is [System.Collections.IEnumerable] -and -not ($property.Value -is [string])) {
-                    # If the value is a collection, check each element
-                    $convertedCollection = @()
-                    foreach ($item in $property.Value) {
-                        if ($item -is [PSCustomObject]) {
-                            $convertedCollection += Convert-ObjectRecursively -InputObject $item
-                        }
-                        else {
-                            $convertedCollection += $item
-                        }
-                    }
-                    $orderedHashtable[$property.Name] = $convertedCollection
-                }
-                else {
-                    # Add the property name and value to the ordered hashtable
-                    $orderedHashtable[$property.Name] = $property.Value
-                }
-            }
-
-            # Return the resulting ordered hashtable
-            return $orderedHashtable
-        }
-    }
-    process {
-        # Call the recursive helper function for each input object
-        Convert-ObjectRecursively -InputObject $InputObject
-    }
-}
- 


### PR DESCRIPTION
### 📝 Pull Request Description:

This pull request introduces a reusable helper script (`TestHelper.ps1`) to support and streamline Pester-based integration tests. It includes the following changes:

---

#### 📁 **New Helper Functions**

The following utility functions were added to `TestHelper.ps1` (located in the `shared` folder):

* `Import-PodeAssembly`: Dynamically loads the appropriate Pode.dll based on the .NET version.
* `Compare-StringRnLn`: Normalizes line endings for accurate string comparison.
* `Convert-PsCustomObjectToOrderedHashtable`: Converts `PSCustomObject` to an ordered hashtable recursively.
* `Compare-Hashtable`: Deep comparison of (nested) hashtables, including arrays and string normalization.
* `Wait-ForWebServer`: Replaces `Start-Sleep` by polling until a web server is available.

---

#### 🔧 **Integration Test Refactor**

All integration tests have been updated to:

* Use the new helper by importing it in `BeforeAll`:

  ```powershell
  BeforeAll {
      $helperPath = (Split-Path -Parent -Path $PSCommandPath) -ireplace 'integration', 'shared'
      . "$helperPath/TestHelper.ps1"
  }
  ```

* Replace `Start-Sleep 10` with:

  ```powershell
  Wait-ForWebServer -Port $Port
  ```

  for more reliable and responsive server readiness checks.

---

#### ✅ **Benefits**

* Improved test robustness by avoiding fixed sleeps.
* Reusable utilities for consistent logic across tests.
* Easier debugging and maintenance of integration test logic.
 
