### PR TITLE
Add `-FilePath` Support to Route Group Functions

### DIFF
--- a/docs/Tutorials/Routes/Utilities/RouteGrouping.md
+++ b/docs/Tutorials/Routes/Utilities/RouteGrouping.md
@@ -1,14 +1,16 @@
 # Route Grouping
 
-Instead of adding multiple Routes all with the same path, middleware, authentication and other values; you can instead create these Routes in a Route Group. This will let you specify a shared base path, middleware, authentication, etc. for multiple Routes.
+Instead of adding multiple Routes all with the same path, middleware, authentication and other values, you can instead create these Routes in a **Route Group**. This lets you specify a shared base path, middleware, authentication, etc. for multiple Routes.
 
 There are Route groupings for normal Routes, Static Routes, and Signal Routes.
 
 ## Routes
 
-You can add a new Route Group using [`Add-PodeRouteGroup`](../../../../Functions/Routes/Add-PodeRouteGroup), and passing a any shared details, plus a `-Routes` scriptblock for the routes to be created within the grouping's scope.
+You can add a new Route Group using [`Add-PodeRouteGroup`](../../../../Functions/Routes/Add-PodeRouteGroup), and passing any shared details, plus either a `-Routes` scriptblock or a `-FilePath` parameter for the routes to be created within the grouping's scope.
 
-For example, the below will add 3 Routes which all share a `/api` base path; some Basic authentication, and some other middleware:
+### Defining Routes Inline
+
+For example, the below will add 3 Routes which all share a `/api` base path, some Basic authentication, and some other middleware:
 
 ```powershell
 $mid = New-PodeMiddleware -ScriptBlock {
@@ -30,11 +32,11 @@ Add-PodeRouteGroup -Path '/api' -Authentication Basic -Middleware $mid -Routes {
 }
 ```
 
-When run, you'll have 3 Routes that all need some Basic authentication at `/api/route1`, `/api/route2`, and `/api/route3`.
+When run, you'll have 3 Routes that all require Basic authentication at `/api/route1`, `/api/route2`, and `/api/route3`.
 
-You can still add custom `-Middleware` on the Routes, and they'll be appended to the shared Middleware from the Group. Other parameters, such as `-ContentType` and `-EndpointName`, if supplied, will override the values passed into the Group.
+You can still add custom `-Middleware` to the Routes, and they'll be appended to the shared Middleware from the Group. Other parameters, such as `-ContentType` and `-EndpointName`, if supplied, will override the values passed into the Group.
 
-You can also embed groups within groups. The following is the same as the above, except this time the last 2 Routes will be at `/api/inner/route2`, and `/api/inner/route3`:
+You can also embed groups within groups. The following is the same as the above, except this time the last 2 Routes will be at `/api/inner/route2` and `/api/inner/route3`:
 
 ```powershell
 $mid = New-PodeMiddleware -ScriptBlock {
@@ -58,9 +60,38 @@ Add-PodeRouteGroup -Path '/api' -Authentication Basic -Middleware $mid -Routes {
 }
 ```
 
+### Defining Routes from a File
+
+You can now use the `-FilePath` parameter as an alternative to the `-Routes` scriptblock. This allows you to define your routes in an external `.ps1` file and reference it, keeping your route definitions modular and maintainable.
+
+```powershell
+Add-PodeRouteGroup -Path '/api' -Authentication Basic -Middleware $mid -FilePath './routes/api-routes.ps1'
+```
+
+Your external `api-routes.ps1` file should contain the same commands you would put inside the `-Routes` scriptblock, for example:
+
+```powershell
+# ./routes/api-routes.ps1
+Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
+    Write-PodeJsonResponse -Value @{ ID = 1 }
+}
+Add-PodeRoute -Method Get -Path '/route2' -ScriptBlock {
+    Write-PodeJsonResponse -Value @{ ID = 2 }
+}
+Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
+    Write-PodeJsonResponse -Value @{ ID = 3 }
+}
+```
+
+The file will be executed in the context of the route group, inheriting all shared parameters such as `-Path`, `-Middleware`, and `-Authentication`.
+
+You can use `-FilePath` **or** `-Routes` (but not both at the same time).
+
+---
+
 ## Static Routes
 
-The Groups for Static Routes work in the same manner as normal Routes, but you'll need to use [`Add-PodeStaticRouteGroup`](../../../../Functions/Routes/Add-PodeStaticRouteGroup) instead:
+The groups for Static Routes work in the same manner as normal Routes, but you'll use [`Add-PodeStaticRouteGroup`](../../../../Functions/Routes/Add-PodeStaticRouteGroup) instead. Both `-Routes` and `-FilePath` are supported:
 
 ```powershell
 Add-PodeStaticRouteGroup -Path '/assets' -Source './content/assets' -Routes {
@@ -69,22 +100,40 @@ Add-PodeStaticRouteGroup -Path '/assets' -Source './content/assets' -Routes {
 }
 ```
 
-This will create 2 Static Routes at `/assets/images` and `/assets/videos`, referencing files from the directories `./content/assets/images` and `./content/assets/videos` respectively.
+Or from an external file:
+
+```powershell
+Add-PodeStaticRouteGroup -Path '/assets' -Source './content/assets' -FilePath './routes/static-assets.ps1'
+```
+
+---
 
 ## Signal Routes
 
-Groupings for Signal Routes also work in the same manner as normal Routes, but you'll need to use [`Add-PodeSignalRouteGroup`](../../../../Functions/Routes/Add-PodeSignalRouteGroup) instead:
+Groupings for Signal Routes also work in the same manner, but you'll use [`Add-PodeSignalRouteGroup`](../../../../Functions/Routes/Add-PodeSignalRouteGroup):
 
 ```powershell
-Add-PodeSignalRoute -Path '/ws' -Routes {
+Add-PodeSignalRouteGroup -Path '/ws' -Routes {
     Add-PodeSignalRoute -Path '/messages1' -ScriptBlock {
         Send-PodeSignal -Value $SignalEvent.Data.Message
     }
-
     Add-PodeSignalRoute -Path '/messages2' -ScriptBlock {
         Send-PodeSignal -Value $SignalEvent.Data.Message
     }
 }
 ```
 
-This will create 2 Signal Routes at `/ws/messages1` and `/ws/messages2`.
+Or using a file:
+
+```powershell
+Add-PodeSignalRouteGroup -Path '/ws' -FilePath './routes/signal-routes.ps1'
+```
+
+---
+
+## Notes
+
+* `-Routes` and `-FilePath` are mutually exclusive: only one may be used per group.
+* Any route/group definitions in the referenced file will be evaluated within the scope of the group, inheriting shared parameters and base path.
+* Nested route groups can use either inline or file-based definitions.
+* If both `-Routes` and `-FilePath` are supplied, an error will be thrown.


### PR DESCRIPTION
### Summary

This PR adds a new `-FilePath` parameter to the following Pode group functions:

* `Add-PodeRouteGroup`
* `Add-PodeStaticRouteGroup`
* `Add-PodeSignalRouteGroup`

This enhancement allows users to define group routes in external `.ps1` files, in addition to the existing inline `-Routes` ScriptBlock. It improves modularity, maintainability, and the ability to reuse route logic across different parts of a Pode application.

---

### Changes

* **New Parameter:**
  Added `-FilePath` as an alternative to `-Routes` for all route grouping functions.

  * Only one of `-Routes` or `-FilePath` can be supplied per group (mutually exclusive).
  * If `-FilePath` is supplied, the referenced file is loaded as a ScriptBlock and executed in the group context, inheriting all shared group parameters.
* **Documentation:**

  * Updated comment-based help headers for each function, clarifying usage of `-FilePath`, with updated parameter documentation and example usage.
  * Added and updated documentation sections and code examples for groupings in main docs.
* **Internal:**

  * Internal logic updated to support both parameter sets.
  * File-based route definitions run in the same scope as inline routes for full feature parity.
  * Parameter validation and error handling added for the new usage pattern.

---

### Usage Examples

**Inline ScriptBlock:**

```powershell
Add-PodeRouteGroup -Path '/api' -Routes {
    Add-PodeRoute -Path '/one' -ScriptBlock { Write-PodeJsonResponse -Value @{ Msg = "One" } }
}
```

**External File:**

```powershell
Add-PodeRouteGroup -Path '/api' -FilePath './routes/api-routes.ps1'
```

*(where `api-routes.ps1` contains the same route definitions as would be placed in `-Routes`)*

---

### Motivation

* Makes it easier to manage and organize large sets of route definitions.
* Allows route definitions to be shared across different parts of a project.
* Simplifies main server scripts by separating configuration from route logic.
* Brings route groupings in line with best practices for maintainable codebases.

---

### Backwards Compatibility

* Existing usage of `-Routes` is unchanged and fully supported.
* No breaking changes; new functionality is fully opt-in.
 