### PR TITLE
Increase CI workflow build timeouts to 40 minutes

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   build:
     runs-on: windows-latest
-
+    timeout-minutes: 40
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     runs-on: windows-latest
-
+    timeout-minutes: 40
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci-pwsh7_5.yml
+++ b/.github/workflows/ci-pwsh7_5.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   build-preview:
     runs-on: ${{ matrix.os }}
-
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Set the timeout-minutes parameter to 40 in all main GitHub Actions CI workflows to prevent premature job termination on longer builds.
 